### PR TITLE
carli/add deployment type to build

### DIFF
--- a/CARTA-AppImage-creator/Dockerfile-carta-appimage-create
+++ b/CARTA-AppImage-creator/Dockerfile-carta-appimage-create
@@ -109,8 +109,8 @@ RUN \
            -DGSL_LIBRARY=/opt/carta-gsl/lib \
            -DGSL_CBLAS_LIBRARY=/opt/carta-gsl/lib \
            -DCMAKE_CXX_FLAGS="-I/opt/carta-gsl/include" \
-           -DCMAKE_CXX_STANDARD_LIBRARIES="-L/opt/carta-gsl/lib" && \
-           -DDEPLOYMENT_TYPE=appimage \
+           -DCMAKE_CXX_STANDARD_LIBRARIES="-L/opt/carta-gsl/lib" \
+           -DDEPLOYMENT_TYPE=appimage && \
   make -j 4
 
 # Prepare the carta-frontend

--- a/CARTA-AppImage-creator/Dockerfile-carta-appimage-create
+++ b/CARTA-AppImage-creator/Dockerfile-carta-appimage-create
@@ -110,6 +110,7 @@ RUN \
            -DGSL_CBLAS_LIBRARY=/opt/carta-gsl/lib \
            -DCMAKE_CXX_FLAGS="-I/opt/carta-gsl/include" \
            -DCMAKE_CXX_STANDARD_LIBRARIES="-L/opt/carta-gsl/lib" && \
+           -DDEPLOYMENT_TYPE=appimage \
   make -j 4
 
 # Prepare the carta-frontend

--- a/Flatpak/org.flatpak.CARTA.yml
+++ b/Flatpak/org.flatpak.CARTA.yml
@@ -8,7 +8,6 @@ finish-args:
   - --socket=session-bus
   - --share=network
   - --share=ipc
-  - --env=DEPLOYMENT_TYPE=flatpak
 
 modules:
   - name: gsl
@@ -156,6 +155,7 @@ modules:
     config-opts:
       - -DCARTA_CASACORE_ROOT=/app
       - -DCartaUserFolderPrefix=.carta
+      - -DDEPLOYMENT_TYPE=flatpak
     sources:
       - type: git
         url: https://github.com/CARTAvis/carta-backend.git

--- a/Flatpak/org.flatpak.CARTA.yml
+++ b/Flatpak/org.flatpak.CARTA.yml
@@ -8,6 +8,7 @@ finish-args:
   - --socket=session-bus
   - --share=network
   - --share=ipc
+  - --env=DEPLOYMENT_TYPE=flatpak
 
 modules:
   - name: gsl

--- a/RPM/carta-backend.spec
+++ b/RPM/carta-backend.spec
@@ -86,16 +86,17 @@ cmake3 ..  -DCMAKE_CXX_FLAGS="-I/usr/include/cfitsio" -DCMAKE_INSTALL_PREFIX=/us
            -DGSL_CBLAS_LIBRARY=/opt/carta-gsl/lib \
            -DGSL_CONFIG=/opt/carta-gsl/bin/gsl-config \
            -DCMAKE_CXX_FLAGS="-I/opt/carta-gsl/include" \
-           -DCMAKE_CXX_STANDARD_LIBRARIES="-L/opt/carta-gsl/lib"
+           -DCMAKE_CXX_STANDARD_LIBRARIES="-L/opt/carta-gsl/lib" \
+           -DDEPLOYMENT_TYPE=rpm
 %endif
 
 %if 0%{?rhel} == 8 || 0%{?rhel} == 9
-cmake3 ..  -DCMAKE_CXX_FLAGS="-I/usr/include/cfitsio" -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DCartaUserFolderPrefix=".carta"
+cmake3 ..  -DCMAKE_CXX_FLAGS="-I/usr/include/cfitsio" -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DCartaUserFolderPrefix=".carta" -DDEPLOYMENT_TYPE=rpm
 %endif
 
 %if 0%{?suse_version} >= 1500
 export CC=gcc-9 CXX=g++-9 FC=gfortran-9 
-cmake ..  -DCMAKE_CXX_FLAGS="-I/usr/include/cfitsio" -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DCartaUserFolderPrefix=".carta"
+cmake ..  -DCMAKE_CXX_FLAGS="-I/usr/include/cfitsio" -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DCartaUserFolderPrefix=".carta" -DDEPLOYMENT_TYPE=rpm
 %endif
 
 make

--- a/Snapcraft/snapcraft.yaml
+++ b/Snapcraft/snapcraft.yaml
@@ -19,6 +19,7 @@ apps:
     environment:
       LD_LIBRARY_PATH: $SNAP/opt/carta-casacore/lib:$SNAP/usr/lib/x86_64-linux-gnu/lapack:$SNAP/usr/lib/x86_64-linux-gnu/blas:$LD_LIBRARY_PATH
       PATH: $SNAP/usr/local/bin:/usr/bin
+      DEPLOYMENT_TYPE: snapcraft
     plugs:
       - desktop      
       - home

--- a/Snapcraft/snapcraft.yaml
+++ b/Snapcraft/snapcraft.yaml
@@ -19,7 +19,6 @@ apps:
     environment:
       LD_LIBRARY_PATH: $SNAP/opt/carta-casacore/lib:$SNAP/usr/lib/x86_64-linux-gnu/lapack:$SNAP/usr/lib/x86_64-linux-gnu/blas:$LD_LIBRARY_PATH
       PATH: $SNAP/usr/local/bin:/usr/bin
-      DEPLOYMENT_TYPE: snapcraft
     plugs:
       - desktop      
       - home
@@ -97,7 +96,7 @@ parts:
     after: 
       - carta-casacore
     cmake-parameters: 
-      - -DCMAKE_CXX_FLAGS="-I$SNAPCRAFT_STAGE/opt/carta-casacore/include -I$SNAPCRAFT_STAGE/opt/carta-casacore/include/casacode -I$SNAPCRAFT_STAGE/opt/carta-casacore/include/casacore" -DCMAKE_CXX_STANDARD_LIBRARIES="-L$SNAPCRAFT_STAGE/opt/carta-casacore/lib" -DCartaUserFolderPrefix=.carta
+      - -DCMAKE_CXX_FLAGS="-I$SNAPCRAFT_STAGE/opt/carta-casacore/include -I$SNAPCRAFT_STAGE/opt/carta-casacore/include/casacode -I$SNAPCRAFT_STAGE/opt/carta-casacore/include/casacore" -DCMAKE_CXX_STANDARD_LIBRARIES="-L$SNAPCRAFT_STAGE/opt/carta-casacore/lib" -DCartaUserFolderPrefix=.carta -DDEPLOYMENT_TYPE=snapcraft
     build-packages:
       - bison  
       - fftw3-dev


### PR DESCRIPTION
This PR is associated with the carta-frontend PR[#2227](https://github.com/CARTAvis/carta-frontend/pull/2227) and carta-backend PR[#1300](https://github.com/CARTAvis/carta-backend/pull/1300). This PR adds ``deployment_type`` cmake flag for AppImage, snapcraft, flatpak and rpm packages.

@crocka Let's make this a PR.
But one change is required in `CARTA-AppImage-creator/Dockerfile-carta-appimage-create`:
The `&&` needs to be moved down one line:

           -DCMAKE_CXX_STANDARD_LIBRARIES="-L/opt/carta-gsl/lib" && \
           -DDEPLOYMENT_TYPE=appimage \

           -DCMAKE_CXX_STANDARD_LIBRARIES="-L/opt/carta-gsl/lib" \
           -DDEPLOYMENT_TYPE=appimage && \