### PR TITLE
adding special handling for the version flag

### DIFF
--- a/macOS_electron/main.js
+++ b/macOS_electron/main.js
@@ -170,6 +170,25 @@ if (items.help) {
 
 }
 
+// Print the --version output from the carta_backend --version output
+if (items.version) {
+
+  var run = exec(path.join(__dirname, 'carta-backend/bin/carta_backend --version'));
+
+  run.stdout.on('data', (data) => {
+    console.log(`${data}`);
+  });
+
+  run.on('error', (err) => {
+    console.error('Error:', err);
+  });
+
+  run.on('exit', () => {
+    process.exit();
+  });
+
+}
+
 // Allow multiple instances of Electron
 const windows = new Set();
 


### PR DESCRIPTION
This should address #13

Here we handle the `--version` flag in the same way as we handle the `--help` flag.
It simply runs the carta_backend component with `--version` and then quits immediately. The startup of the Electron component is skipped entirely.

To test, you could copy & paste the new lines into your `/Applications/CARTA.app/Contents/Resources/app/main.js` file, or we could merge it now and you could test in CARTA v4.1.

At the moment we still see `CARTA will use the default ephemerides and geodetic data.` being printed too, but that will be eliminated with [#1308](https://github.com/CARTAvis/carta-backend/pull/1308)

As for the snippet problem, I think that error comes up because the carta_backend can not find (or create or write to?) `~/.carta/config`. When we build the Electron version we build the carta_backend with `-DCartaUserFolderPrefix=".carta"` for main releases and `-DCartaUserFolderPrefix=".carta-beta"` for beta releases. I'm fairly sure our v4.0.0 Electron version is built correctly because I did not see the snippet error when testing.

Before this new version flag branch, I do see the snippet error dialog box when I do `carta --version`. But that is because the carta_backend prints the version correctly, but Electron also opens the carta-frontend which is then unable to connect to the carta_backend as it has just stopped and is not running.

Where is the snippet error problem posted? The above suggests to me that the user could be trying to run the Electron version of CARTA on an unsupported macOS version so the carta_backend can not run and crashes immediately and hence the snippet error dialog. But it is just a guess.