### PR TITLE
ignore casa_data_autoupdate with version and help flags

### DIFF
--- a/CARTA-AppImage-creator/AppRun
+++ b/CARTA-AppImage-creator/AppRun
@@ -21,7 +21,11 @@ if [ ! -z $FIRST_IP ]; then
     export SERVER_IP=$FIRST_IP
 fi
 
-$DIR/bin/casa_data_autoupdate
+if [[ ! " $@ " =~ ( --version | -v | --help | -h ) ]]; then
+    if [ -x "$(command -v casa_data_autoupdate)" ]; then
+        $DIR/bin/casa_data_autoupdate
+    fi
+fi
 
 $DIR/bin/carta_backend "$@"
 


### PR DESCRIPTION
This will incorporate carta-backend [PR#1308](https://github.com/CARTAvis/carta-backend/pull/1308) into the AppRun startup script.

It is a small change to prevent `casa_data_autoupdate` being called if the --help or --version flag is called.

> if [[ ! " $@ " =~ ( --version | -v | --help | -h ) ]]; then
>     if [ -x "$(command -v casa_data_autoupdate)" ]; then
>         $DIR/bin/casa_data_autoupdate
>     fi
> fi