### PR TITLE
Update the Mac electron builder for notarization

### DIFF
--- a/macOS_electron/README.md
+++ b/macOS_electron/README.md
@@ -131,6 +131,12 @@ If not previously set up, get the code-signing certificate on your Mac with a pr
 	```
 	npm install
 	```
+	Currently, when building on arm64, the “portscanner” package seems to run something called deasync and that gives errors about "The binary uses an SDK older than the 10.9 SDK." The easy fix is to just delete the problematic folders as they are not used first:
+	```
+	rm -rf node_modules/deasync/bin/darwin-x64-node-0.10
+	rm -rf node_modules/deasync/bin/darwin-x64-node-0.11
+	rm -rf node_modules/deasync/bin/darwin-x64-node-0.12
+	```
 2. Double-check that it works:
 	```
 	npm start
@@ -140,8 +146,18 @@ If not previously set up, get the code-signing certificate on your Mac with a pr
 3. Make sure `electron-builder` is installed and accessible:
 	```
 	npm install -g electron-builder
-	```	
-4. Run the electron-builder:
+	```
+4. Export a few variables for notarizing:
+	```
+	export DEBUG=electron-notarize*
+	export APPLE_APP_SPECIFIC_PASSWORD=<Your app specific password generated on https://developer.apple.com>
+	export APPLE_ID=<Your Apple Developer email address>
+	export APPLE_TEAM_ID=<Your Apple Team ID assigned by Apple>
+	export API_KEY_ID=<Your app key ID generated on https://appstoreconnect.apple.com>
+	export API_KEY_ISSUER_ID=<Your app issuer ID generated on https://appstoreconnect.apple.com>
+	```
+5. Create a key file "AuthKey_<API_KEY_ID>.p8", save a private key (generated on https://appstoreconnect.apple.com) in this file, and then put it under directories "/Users/<user_name>/private_keys" and "/Users/<user_name>".
+6. Run the electron-builder:
 	**Note**: electron-builder can interchangeably build the Electron component (The app window that displays the frontend) on both an Intel or M1 Macs, but the **carta_backend** executable itself first needs to be built on either Intel *or* M1. For example, an M1 Mac can create the Electron component for Intel Macs, but you need to copy over a carta-backend packaged for Intel before issuing the electron-builder command.
 	
    When you have a carta-backend built and packaged on Intel x86 computer:

--- a/macOS_electron/package.json
+++ b/macOS_electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "CARTA",
-  "version": "4.1.0",
-  "description": "2024 CARTA Desktop",
+  "version": "<CARTA release version>",
+  "description": "<Year> CARTA Desktop",
   "main": "main.js",
   "scripts": {
     "start": "electron ."
@@ -14,17 +14,28 @@
   "author": "GitHub",
   "license": "CC0-1.0",
   "devDependencies": {
-    "electron": "27.2.4",
-    "electron-notarize": "^0.2.1",
-    "electron-packager": "^13.1.1"
+    "@electron/universal": "1.3.4",
+    "@electron/notarize": "^2.1.0",
+    "electron-builder-notarize": "1.5.2",
+    "electron": "19.0.13",
+    "electron-packager": "^17.1.1",
+    "find-port-free-sync": "^1.0.7",
+    "deasync": "^0.1.28",
+    "minimist": "^1.2.5",
+    "uuid": "^9.0.0"
   },
   "dependencies": {
+    "@electron/universal": "1.3.4",
+    "deasync": "^0.1.28",
     "electron-context-menu": "^0.12.0",
     "electron-installer-dmg": "^3.0.0",
+    "electron-window-state": "^5.0.3",
     "electron-window-state-manager": "^0.3.2",
+    "express": "^4.16.4",
     "find-free-port-sync": "^1.0.0",
     "minimist": "^1.2.3",
-    "uuid": "^8.3.2"
+    "node-gyp": "^9.1.0",
+    "uuid": "^9.0.0"
   },
   "mac": {
     "hardenedRuntime": true,
@@ -33,7 +44,13 @@
     "entitlementsInherit": "entitlements.mac.plist"
   },
   "build": {
-    "afterSign": "scripts/notarize.js",
+    "appId": "cartavis.org",
+    "afterSign": "electron-builder-notarize",
+    "mac": {
+      "notarize": {
+        "teamId": "<Your Apple Developer Team ID assigned by Apple>"
+      }
+    },
     "asar": "false"
   },
   "dmg": {

--- a/macOS_electron/scripts/notarize.js
+++ b/macOS_electron/scripts/notarize.js
@@ -9,9 +9,9 @@ exports.default = async function notarizing(context) {
   const appName = context.packager.appInfo.productFilename;
 
   return await notarize({
-    appBundleId: '<Your Apple Developer ID> ',
     appPath: `${appOutDir}/${appName}.app`,
     appleId: '<Your Apple Developer email address>',
-    appleIdPassword: '<Your app-specific-password>',
+    appleIdPassword: '<Your app specific password>',
+    teamId: '<Your Apple Team ID assigned by Apple>',
     });
   };


### PR DESCRIPTION
This is the Mac electron builder update in response to the deprecation of `altool` for notarization. @ajm-ska established a new method for notarization on Apple's cloud servers. I just updated this repo for documentation.