### PR TITLE
Yuhsuan/add dockerfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ It includes:
 - RPM spec files
 - Flatpak version
 - Snapcraft version
+- cartavis/carta Docker image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:24.04
+
+# Install the basic packages
+RUN \
+    apt-get update && \
+    apt-get -y upgrade && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-suggests --no-install-recommends software-properties-common && \
+    apt-add-repository -y -s ppa:kernsuite/kern-7 && \
+    add-apt-repository -y ppa:cartavis-team/carta && \
+    apt-get -y install carta casacore-data && \
+    apt-get -y remove --auto-remove software-properties-common && \
+    apt-get -y clean
+
+# Set up initial images directory and initial preferences
+RUN mkdir -p /images && \
+    cp /usr/share/carta/default.fits /images/ && \
+    mkdir -p /home/cartauser/.carta/config && \
+    echo '{"telemetryConsentShown": true, "telemetryMode":"none"}' > /home/cartauser/.carta/config/preferences.json
+
+# Set up a non-root user
+RUN \
+    groupadd -g 1001 cartauser && \
+    useradd -r -u 1001 -g cartauser cartauser && \
+    chown -R cartauser:cartauser /home/cartauser/.carta
+
+# Forward port so that the webapp can properly access it from outside of the container
+EXPOSE 3002
+
+ENV CARTA_DOCKER_DEPLOYMENT=1
+USER cartauser
+WORKDIR /home/cartauser
+
+ENTRYPOINT ["/usr/bin/carta_backend", "--no_browser", "--top_level_folder", "/images", "/images"]
+CMD ["$@"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,6 @@ RUN \
 
 # Set up initial images directory and initial preferences
 RUN mkdir -p /images && \
-    cp /usr/share/carta/default.fits /images/ && \
     mkdir -p /home/cartauser/.carta/config && \
     echo '{"telemetryConsentShown": true, "telemetryMode":"none"}' > /home/cartauser/.carta/config/preferences.json
 

--- a/docker/Dockerfile-beta
+++ b/docker/Dockerfile-beta
@@ -1,0 +1,35 @@
+FROM ubuntu:24.04
+
+# Install the basic packages
+RUN \
+    apt-get update && \
+    apt-get -y upgrade && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-suggests --no-install-recommends software-properties-common && \
+    apt-add-repository -y -s ppa:kernsuite/kern-7 && \
+    add-apt-repository -y ppa:cartavis-team/carta && \
+    apt-get -y install carta-beta casacore-data && \
+    apt-get -y remove --auto-remove software-properties-common && \
+    apt-get -y clean
+
+# Set up initial images directory and initial preferences
+RUN mkdir -p /images && \
+    cp /usr/share/carta/default.fits /images/ && \
+    mkdir -p /home/cartauser/.carta-beta/config && \
+    echo '{"telemetryConsentShown": true, "telemetryMode":"none"}' > /home/cartauser/.carta-beta/config/preferences.json
+
+# Set up a non-root user
+RUN \
+    groupadd -g 1001 cartauser && \
+    useradd -r -u 1001 -g cartauser cartauser && \
+    chown -R cartauser:cartauser /home/cartauser/.carta-beta
+
+# Forward port so that the webapp can properly access it from outside of the container
+EXPOSE 3002
+
+ENV CARTA_DOCKER_DEPLOYMENT=1
+USER cartauser
+WORKDIR /home/cartauser
+
+ENTRYPOINT ["/usr/bin/carta_backend", "--no_browser", "--top_level_folder", "/images", "/images"]
+CMD ["$@"]

--- a/docker/Dockerfile-beta
+++ b/docker/Dockerfile-beta
@@ -14,7 +14,6 @@ RUN \
 
 # Set up initial images directory and initial preferences
 RUN mkdir -p /images && \
-    cp /usr/share/carta/default.fits /images/ && \
     mkdir -p /home/cartauser/.carta-beta/config && \
     echo '{"telemetryConsentShown": true, "telemetryMode":"none"}' > /home/cartauser/.carta-beta/config/preferences.json
 

--- a/docker/Dockerfile-beta
+++ b/docker/Dockerfile-beta
@@ -30,5 +30,5 @@ ENV CARTA_DOCKER_DEPLOYMENT=1
 USER cartauser
 WORKDIR /home/cartauser
 
-ENTRYPOINT ["/usr/bin/carta_backend", "--no_browser", "--top_level_folder", "/images", "/images"]
+ENTRYPOINT ["/usr/bin/carta_backend", "--no_browser", "/images"]
 CMD ["$@"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,23 @@
+# Repository overview
+
+This is [CARTA](https://cartavis.org) running in an Ubuntu 24.04 based Docker container.
+
+The simplest way to run it is as follows:
+
+```
+docker run -ti -p 3002:3002 -v $HOME/.carta:/home/cartauser/.carta -v $PWD:/images cartavis/carta
+```
+CARTA will automatically start using the container path **/images** in its file browser.  The **-v $PWD:/images** Docker flag maps your current local directory, **$PWD**, to the container path **/images**. Alternatively, you could use a specific path other than **$PWD**. For example, **-v /data/image-cubes:/images**.
+
+For persistent preferences and log files, you should mount your local **~/.carta** (or **~/.carta-beta** for beta versions) directory to the **/home/cartauser/.carta** (or **/home/cartauser/.carta-beta** for beta versions) container path. For example, **-v $HOME/.carta:/home/cartauser/.carta**.
+
+Port 3002 is the first default port used by CARTA so the **-p 3002:3002** Docker flag opens and maps port 3002 inside the container to port 3002 on the Docker host system.
+
+A unique URL will be displayed in the terminal. Copy & Paste the unique URL into your local web browser to gain access to the CARTA frontend interface.
+
+Any additional CARTA flags can be appended to the command. For example, to view the 'help' output:
+```
+docker run -ti -p 3002:3002  -v $HOME/.carta:/home/cartauser/.carta -v $PWD:/images cartavis/carta --help
+```
+
+For more information about CARTA, please refer to the [CARTA user manual](https://carta.readthedocs.io/en/latest/).

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,7 +5,7 @@ This is [CARTA](https://cartavis.org) running in an Ubuntu 24.04 based Docker co
 The simplest way to run it is as follows:
 
 ```
-docker run -ti -p 3002:3002 -v $HOME/.carta:/home/cartauser/.carta -v $PWD:/images cartavis/carta
+docker run --rm -ti -p 3002:3002 -v $HOME/.carta:/home/cartauser/.carta -v $PWD:/images cartavis/carta
 ```
 CARTA will automatically start using the container path **/images** in its file browser.  The **-v $PWD:/images** Docker flag maps your current local directory, **$PWD**, to the container path **/images**. Alternatively, you could use a specific path other than **$PWD**. For example, **-v /data/image-cubes:/images**.
 
@@ -17,7 +17,7 @@ A unique URL will be displayed in the terminal. Copy & Paste the unique URL into
 
 Any additional CARTA flags can be appended to the command. For example, to view the 'help' output:
 ```
-docker run -ti -p 3002:3002  -v $HOME/.carta:/home/cartauser/.carta -v $PWD:/images cartavis/carta --help
+docker run --rm -ti -p 3002:3002  -v $HOME/.carta:/home/cartauser/.carta -v $PWD:/images cartavis/carta --help
 ```
 
 For more information about CARTA, please refer to the [CARTA user manual](https://carta.readthedocs.io/en/latest/).


### PR DESCRIPTION
Includes Dockerfiles for creating cartavis/carta in this reop.

Some updates from https://github.com/CARTAvis/carta-backend/blob/angus/minimal_dockerfile/Dockerfiles/Dockerfile-minimal-ubuntu-20.04:
- Created two files for stable and beta releases.
- Updated the base image to Ubuntu 24.04.
- Removed the step of copying `default.fits` file.