### PR TITLE
update RPM spec for carta v5 and v5-beta

### DIFF
--- a/RPM/carta-backend-beta.spec
+++ b/RPM/carta-backend-beta.spec
@@ -15,7 +15,7 @@
 %define beta_install_path /opt/carta-beta
 
 Name:           carta-backend-beta
-Version:        5.0+2025.7.22
+Version:        5.0+2025.7.31
 Release:        1
 Summary:        CARTA - Cube Analysis and Rendering Tool for Astronomy
 License:        GPL-3.0-only
@@ -72,7 +72,7 @@ This package provides the release version of the backend component.
 rm -rf %{NVdir}
 git clone %{url}.git %{NVdir}
 cd %{NVdir}
-git checkout v5.0.1
+git checkout v5.0.3
 git submodule update --init
 
 %build
@@ -190,6 +190,9 @@ fi
 %exclude %{beta_install_path}/lib64/pkgconfig/pugixml.pc
 
 %changelog
+* Thu Jul 31 2025 Po-Sheng Huang <posheng@asiaa.sinica.edu.tw> 5.0+2025.7.31
+  - carta-backend v5.0.3 for CARTA 5.0-beta.2025.7.31 release
+
 * Tue Jul 22 2025 Po-Sheng Huang <posheng@asiaa.sinica.edu.tw> 5.0+2025.7.22
   - carta-backend v5.0.1 for CARTA 5.0-beta.2025.7.22 release
 

--- a/RPM/carta-backend-beta.spec
+++ b/RPM/carta-backend-beta.spec
@@ -15,7 +15,7 @@
 %define beta_install_path /opt/carta-beta
 
 Name:           carta-backend-beta
-Version:        5.0+2025.2.14
+Version:        5.0+2025.7.22
 Release:        1
 Summary:        CARTA - Cube Analysis and Rendering Tool for Astronomy
 License:        GPL-3.0-only
@@ -72,8 +72,8 @@ This package provides the release version of the backend component.
 rm -rf %{NVdir}
 git clone %{url}.git %{NVdir}
 cd %{NVdir}
-git checkout v5.0.0-beta.1
-git submodule update --init --recursive
+git checkout v5.0.1
+git submodule update --init
 
 %build
 cd %{NVdir}
@@ -190,6 +190,9 @@ fi
 %exclude %{beta_install_path}/lib64/pkgconfig/pugixml.pc
 
 %changelog
+* Tue Jul 22 2025 Po-Sheng Huang <posheng@asiaa.sinica.edu.tw> 5.0+2025.7.22
+  - carta-backend v5.0.1 for CARTA 5.0-beta.2025.7.22 release
+
 * Thu Jun 12 2025 Kuan-Chou Hou <kchou@asiaa.sinica.edu.tw> 5.0+2025.2.14
   - Remove rhel7 specific requirements and upgrade zfp to 1.0.1
 

--- a/RPM/carta-backend.spec
+++ b/RPM/carta-backend.spec
@@ -4,7 +4,7 @@
 %define debug_package %{nil}
 
 Name:           carta-backend
-Version:        5.0.1
+Version:        5.0.3
 Release:        1
 Summary:        CARTA - Cube Analysis and Rendering Tool for Astronomy
 License:        GPL-3.0-only
@@ -12,8 +12,8 @@ URL:            https://github.com/CARTAvis/carta-backend
 
 BuildArch: %{_arch}
 
-Obsoletes: carta-backend <= 5.0.1
-Obsoletes: carta-backend = 5.0.1~rc.0
+Obsoletes: carta-backend <= 5.0.3
+Obsoletes: carta-backend = 5.0.3~rc.0
 
 BuildRequires: git
 BuildRequires: blas-devel
@@ -150,6 +150,9 @@ fi
 %{_datadir}/icons/hicolor/symbolic/apps/cartaviewer.svg
 
 %changelog
+* Thu Jul 31 2025 Po-Sheng Huang <posheng@asiaa.sinica.edu.tw> 5.0.3
+  - carta-backend component for the CARTA 5.0.3 release
+
 * Tue Jul 22 2025 Po-Sheng Huang <posheng@asiaa.sinica.edu.tw> 5.0.1
   - carta-backend component for the CARTA 5.0 release
 

--- a/RPM/carta-backend.spec
+++ b/RPM/carta-backend.spec
@@ -4,7 +4,7 @@
 %define debug_package %{nil}
 
 Name:           carta-backend
-Version:        5.0.0
+Version:        5.0.1
 Release:        1
 Summary:        CARTA - Cube Analysis and Rendering Tool for Astronomy
 License:        GPL-3.0-only
@@ -12,8 +12,8 @@ URL:            https://github.com/CARTAvis/carta-backend
 
 BuildArch: %{_arch}
 
-Obsoletes: carta-backend < 5.0.0
-Obsoletes: carta-backend = 5.0.0~rc.0
+Obsoletes: carta-backend <= 5.0.1
+Obsoletes: carta-backend = 5.0.1~rc.0
 
 BuildRequires: git
 BuildRequires: blas-devel
@@ -23,7 +23,7 @@ BuildRequires: cmake
 %else
 BuildRequires: cmake3
 %endif
-BuildRequires:  carta-cfitsio-v450-devel
+BuildRequires:  carta-cfitsio-v450-curl-devel
 %if 0%{?suse_version} >= 1500
 BuildRequires:  gcc9-c++
 BuildRequires:  gcc9-fortran
@@ -40,7 +40,7 @@ BuildRequires: zfp-devel >= 1.0.1
 BuildRequires: gsl-devel
 
 Requires: blas
-Requires: carta-cfitsio-v450
+Requires: carta-cfitsio-v450-curl
 Requires: carta-casacore-nocurl
 Requires: hdf5
 %if 0%{?suse_version} >= 1500
@@ -67,7 +67,7 @@ git clone %{url}.git %{NVdir}
 cd %{NVdir}
 git checkout v%{version}
 # git checkout dev
-git submodule update --init --recursive
+git submodule update --init
 
 %build
 cd %{NVdir}
@@ -150,6 +150,9 @@ fi
 %{_datadir}/icons/hicolor/symbolic/apps/cartaviewer.svg
 
 %changelog
+* Tue Jul 22 2025 Po-Sheng Huang <posheng@asiaa.sinica.edu.tw> 5.0.1
+  - carta-backend component for the CARTA 5.0 release
+
 * Thu Jun 12 2025 Kuan-Chou Hou <kchou@asiaa.sinica.edu.tw> 5.0.0
   - Remove rhel7 specific requirements
   - Upgrade zfp to 1.0.1

--- a/RPM/carta-beta.spec
+++ b/RPM/carta-beta.spec
@@ -1,5 +1,5 @@
 Name:           carta-beta
-Version:        5.0+2025.7.22
+Version:        5.0+2025.7.31
 Release:        1
 Summary:        CARTA - Cube Analysis and Rendering Tool for Astronomy
 License:        GPL-3.0-only
@@ -7,8 +7,8 @@ URL:            https://github.com/CARTAvis/carta-backend
 
 BuildArch: %{_arch}
 
-Requires: carta-backend-beta = 5.0+2025.7.22
-Requires: carta-frontend-beta = 5.0+2025.7.22
+Requires: carta-backend-beta
+Requires: carta-frontend-beta
 
 %description
 CARTA is a next generation image visualization and analysis tool designed for ALMA, VLA, and SKA pathfinders.
@@ -26,6 +26,9 @@ This package provides the beta versions of the carta-backend and carta-frontend 
 %files
 
 %changelog
+* Thu Jul 31 2025 Po-Sheng Huang <posheng@asiaa.sinica.edu.tw> 5.0+2025.7.31
+  - carta-beta metapackage for the CARTA 5.0-beta.2025.7.31 release
+
 * Tue Jul 22 2025 Po-Sheng Huang <posheng@asiaa.sinica.edu.tw> 5.0+2025.7.22
   - carta-beta metapackage for the CARTA 5.0-beta.2025.7.22 release
 

--- a/RPM/carta-beta.spec
+++ b/RPM/carta-beta.spec
@@ -1,5 +1,5 @@
 Name:           carta-beta
-Version:        5.0+2025.2.14
+Version:        5.0+2025.7.22
 Release:        1
 Summary:        CARTA - Cube Analysis and Rendering Tool for Astronomy
 License:        GPL-3.0-only
@@ -7,8 +7,8 @@ URL:            https://github.com/CARTAvis/carta-backend
 
 BuildArch: %{_arch}
 
-Requires: carta-backend-beta = 5.0+2025.2.14
-Requires: carta-frontend-beta = 5.0+2025.2.14
+Requires: carta-backend-beta = 5.0+2025.7.22
+Requires: carta-frontend-beta = 5.0+2025.7.22
 
 %description
 CARTA is a next generation image visualization and analysis tool designed for ALMA, VLA, and SKA pathfinders.
@@ -26,6 +26,9 @@ This package provides the beta versions of the carta-backend and carta-frontend 
 %files
 
 %changelog
+* Tue Jul 22 2025 Po-Sheng Huang <posheng@asiaa.sinica.edu.tw> 5.0+2025.7.22
+  - carta-beta metapackage for the CARTA 5.0-beta.2025.7.22 release
+
 * Fri Feb 14 2025 Cheng-Chin Chiang <chcchiang@asiaa.sinica.edu.tw> 5.0+2025.2.14
   - carta-beta metapackage for the CARTA 5.0-beta.1 release
 

--- a/RPM/carta-casacore-nocurl.spec
+++ b/RPM/carta-casacore-nocurl.spec
@@ -159,6 +159,9 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) %_sysconfdir/ld.so.conf.d/%{name}.conf
 
 %changelog
+* Thu Jul 24 2025 Po-Sheng Huang <posheng@asiaa.sinica.edu.tw> 3.5.0+6.6.0+2024.1.18
+- Update measures-data which downloads the latest geodeditc and ephemerides
+
 * Thu Jun 12 2025 Kuan-Chou Hou <kchou@asiaa.sinica.edu.tw> 3.5.0+6.6.0+2024.1.18
 - Remove rhel7 specific requirements
 

--- a/RPM/carta-frontend-beta.spec
+++ b/RPM/carta-frontend-beta.spec
@@ -8,8 +8,8 @@
 %undefine _disable_source_fetch
 
 %define beta_install_path /opt/carta-beta
-%define frontend_version 5.0.2
-%define version_date 2025.7.22
+%define frontend_version 5.0.3
+%define version_date 2025.7.31
 
 Name:           carta-frontend-beta
 Version:        5.0+%{version_date}
@@ -47,6 +47,9 @@ rm -rf %{buildroot}
 %{beta_install_path}/share/carta/frontend
 
 %changelog
+* Thu Jul 31 2025 Po-Sheng Huang <posheng@asiaa.sinica.edu.tw> 5.0+2025.7.31
+  - Custom carta-frontend-beta component for the CARTA 5.0-beta.2025.7.31 release
+
 * Tue Jul 22 2025 Po-Sheng Huang <posheng@asiaa.sinica.edu.tw> 5.0+2025.7.22
   - Custom carta-frontend-beta component for the CARTA 5.0-beta.2025.7.22 release
 

--- a/RPM/carta-frontend-beta.spec
+++ b/RPM/carta-frontend-beta.spec
@@ -8,17 +8,17 @@
 %undefine _disable_source_fetch
 
 %define beta_install_path /opt/carta-beta
-%define frontend_version 5.0.0-beta.1c
-%define version_date 2025.2.14
+%define frontend_version 5.0.2
+%define version_date 2025.7.22
 
 Name:           carta-frontend-beta
-Version:        5.0+${version_date}
+Version:        5.0+%{version_date}
 Release:        1
 Summary:        carta-frontend-beta as needed by carta-beta
 
 License:        GPL-3+
 URL:            https://github.com/CARTAvis/carta-frontend
-Source0:        https://registry.npmjs.org/carta-frontend/-/carta-frontend-${frontend_version}.tgz
+Source0:        https://registry.npmjs.org/carta-frontend/-/carta-frontend-%{frontend_version}.tgz
 
 BuildArch: noarch
 
@@ -28,7 +28,7 @@ Requires a carta-backend-beta.
 
 %prep
 # %setup -q
-tar -xzf %{_sourcedir}/carta-frontend-${frontend_version}.tgz
+tar -xzf %{_sourcedir}/carta-frontend-%{frontend_version}.tgz
 rm -rf carta-frontend-beta-%{version}
 mv package carta-frontend-beta-%{version}
 cd carta-frontend-beta-%{version}
@@ -47,6 +47,9 @@ rm -rf %{buildroot}
 %{beta_install_path}/share/carta/frontend
 
 %changelog
+* Tue Jul 22 2025 Po-Sheng Huang <posheng@asiaa.sinica.edu.tw> 5.0+2025.7.22
+  - Custom carta-frontend-beta component for the CARTA 5.0-beta.2025.7.22 release
+
 * Thu Feb 14 2025 Cheng-Chin Chiang <chcchiang@asiaa.sinica.edu.tw> 5.0+2025.2.14
   - Custom carta-frontend-beta component for the CARTA 5.0-beta.1 release
   

--- a/RPM/carta-frontend.spec
+++ b/RPM/carta-frontend.spec
@@ -3,18 +3,18 @@
 %undefine _disable_source_fetch
 
 # %define frontend_version 5.0.0-dev
-%define frontend_version 5.0.0
+%define frontend_version 5.0.2
 
 Name:           carta-frontend
-Version:        5.0.0
+Version:        5.0.2
 Release:        1
 Summary:        carta-frontend as needed by carta
 License:        GPL-3+
 URL:            https://github.com/CARTAvis/carta-frontend
 Source0:        https://registry.npmjs.org/carta-frontend/-/carta-frontend-%{frontend_version}.tgz
 
-Obsoletes: carta-frontend < 5.0.0
-Obsoletes: carta-frontend = 5.0.0~rc.0
+Obsoletes: carta-frontend <= 5.0.2
+Obsoletes: carta-frontend = 5.0.2~rc.0
 
 BuildArch: noarch
 
@@ -43,6 +43,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/carta/frontend
 
 %changelog
+* Tue Jul 22 2025 Po-Sheng Huang <posheng@asiaa.sinica.edu.tw> 5.0.2
+  - carta-frontend component for the CARTA 5.0 release
+
 * Thu Jun 12 2025 Kuan-Chou Hou <kchou@asiaa.sinica.edu.tw> 5.0.0
   - carta-frontend component for the CARTA 5.0 release
 

--- a/RPM/carta-frontend.spec
+++ b/RPM/carta-frontend.spec
@@ -3,18 +3,18 @@
 %undefine _disable_source_fetch
 
 # %define frontend_version 5.0.0-dev
-%define frontend_version 5.0.2
+%define frontend_version 5.0.3
 
 Name:           carta-frontend
-Version:        5.0.2
+Version:        5.0.3
 Release:        1
 Summary:        carta-frontend as needed by carta
 License:        GPL-3+
 URL:            https://github.com/CARTAvis/carta-frontend
 Source0:        https://registry.npmjs.org/carta-frontend/-/carta-frontend-%{frontend_version}.tgz
 
-Obsoletes: carta-frontend <= 5.0.2
-Obsoletes: carta-frontend = 5.0.2~rc.0
+Obsoletes: carta-frontend <= 5.0.3
+Obsoletes: carta-frontend = 5.0.3~rc.0
 
 BuildArch: noarch
 
@@ -43,6 +43,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/carta/frontend
 
 %changelog
+* Thu Jul 31 2025 Po-Sheng Huang <posheng@asiaa.sinica.edu.tw> 5.0.3
+  - carta-frontend component v5.0.3 for the CARTA 5.0.3 release
+
 * Tue Jul 22 2025 Po-Sheng Huang <posheng@asiaa.sinica.edu.tw> 5.0.2
   - carta-frontend component for the CARTA 5.0 release
 

--- a/RPM/carta.spec
+++ b/RPM/carta.spec
@@ -1,5 +1,5 @@
 Name:           carta
-Version:        5.0.0
+Version:        5.0.3
 Release:        1
 Summary:        CARTA - Cube Analysis and Rendering Tool for Astronomy
 License:        GPL-3.0-only
@@ -7,11 +7,11 @@ URL:            https://github.com/CARTAvis/carta-backend
 
 BuildArch: %{_arch}
 
-Obsoletes: carta <= 5.0.0
-Obsoletes: carta = 5.0.0~rc.0
+Obsoletes: carta <= 5.0.3
+Obsoletes: carta = 5.0.3~rc.0
 
-Requires: carta-backend = 5.0.1
-Requires: carta-frontend = 5.0.2
+Requires: carta-backend
+Requires: carta-frontend
 
 %description
 CARTA is a next generation image visualization and analysis tool designed for ALMA, VLA, and SKA pathfinders.
@@ -29,6 +29,9 @@ This package provides the beta versions of the carta-backend and carta-frontend 
 %files
 
 %changelog
+* Thu Jul 31 2025 Po-Sheng Huang <posheng@asiaa.sinica.edu.tw> 5.0.3
+  - Update backend v5.0.3 and frontend v5.0.3
+
 * Tue Jul 22 2025 Po-Sheng Huang <posheng@asiaa.sinica.edu.tw> 5.0.0
   - Update backend v5.0.1 and frontend v5.0.2
 

--- a/RPM/carta.spec
+++ b/RPM/carta.spec
@@ -7,11 +7,11 @@ URL:            https://github.com/CARTAvis/carta-backend
 
 BuildArch: %{_arch}
 
-Obsoletes: carta < 5.0.0
+Obsoletes: carta <= 5.0.0
 Obsoletes: carta = 5.0.0~rc.0
 
-Requires: carta-backend = 5.0.0
-Requires: carta-frontend = 5.0.0
+Requires: carta-backend = 5.0.1
+Requires: carta-frontend = 5.0.2
 
 %description
 CARTA is a next generation image visualization and analysis tool designed for ALMA, VLA, and SKA pathfinders.
@@ -29,6 +29,9 @@ This package provides the beta versions of the carta-backend and carta-frontend 
 %files
 
 %changelog
+* Tue Jul 22 2025 Po-Sheng Huang <posheng@asiaa.sinica.edu.tw> 5.0.0
+  - Update backend v5.0.1 and frontend v5.0.2
+
 * Thu Jun 12 2025 Kuan-Chou Hou <kchou@asiaa.sinica.edu.tw> 5.0.0
   - CARTA 5.0 release
 

--- a/RPM/measures-data-srpm.sh
+++ b/RPM/measures-data-srpm.sh
@@ -10,8 +10,8 @@ fi
 if ! docker info &> /dev/null; then
     echo "Docker is not running. Please start Docker and try again."
     exit 1
-fi
-
+fi  
+    
 # if no carta-rpmbuild image exists, build it
 if ! docker images | grep -q carta-rpmbuild; then
     echo "Building carta-rpmbuild image..."
@@ -56,15 +56,14 @@ docker start srpm_file
 docker cp $SPEC srpm_file:/root/rpmbuild/SPECS/
 docker cp $SOURCE_FILE srpm_file:/root/rpmbuild/SOURCES/
 docker exec -it srpm_file /bin/bash -c "rpmbuild -bs /root/rpmbuild/SPECS/$SPEC"
-srpm_output=$(docker exec srpm_file ls /root/rpmbuild/SRPMS)
+srpm_output=$(docker exec srpm_file bash -c 'ls /root/rpmbuild/SRPMS/measures*.rpm | xargs -n 1 basename')
 docker cp srpm_file:/root/rpmbuild/SRPMS/${srpm_output} .
 docker stop srpm_file
 docker rm -f srpm_file
 
 if [ -f "${srpm_output}" ]; then
-    echo "SRPM file ${srpm_output} created successfully."
+    echo "SRPM file SRPM file ${srpm_output}  created successfully."
 else
     echo "Failed to create SRPM file."
     exit 1
 fi
-

--- a/RPM/measures-data.spec
+++ b/RPM/measures-data.spec
@@ -2,7 +2,7 @@
 %undefine _disable_source_fetch
 
 Name:           measures-data
-Version:        2025.2.13
+Version:        2025.7.24
 Release:        1%{?dist}
 Summary:        CASA ephemerides and geodetic data
 License:        GPL-3+
@@ -31,6 +31,9 @@ rm -rf $RPM_BUILD_ROOT
 /usr/share/casacore/data/geodetic/
 
 %changelog
+* Thu Jul 24 2025 Po-Sheng Huang <posheng@asiaa.sinica.edu.tw> 2025.7.24
+- Download latest geodeditc and ephemerides direct from ftp.astron.nl
+
 * Mon Feb 17 2025 Cheng-Chin Chiang <chcchiang@asiaa.sinica.edu.tw> 2025.2.17
 - Download latest geodeditc and ephemerides direct from ftp.astron.nl
 

--- a/RPM/spec_modification.sh
+++ b/RPM/spec_modification.sh
@@ -5,8 +5,8 @@
 RELEASE=TRUE # set to TRUE to release a new version, or FALSE to publish a dev version
 # RELEASE=FALSE # set to TRUE to release a new version, or FALSE to publish a dev version
 VERSION=5.0.0
-BACKEND_VERSION=5.0.0
-FRONTEND_VERSION=5.0.0
+BACKEND_VERSION=5.0.1
+FRONTEND_VERSION=5.0.2
 OBSOLETE_VERSION=5.0.0
 
 


### PR DESCRIPTION
We update RPM files for CARTA v5 and v5-beta, including:
  - CARTA release version 5.0.0
  - frontend v5.0.2
  - backend v5.0.1
  - zfp 1.0.1, using gcc-toolset-11
  - carta-casacore-nocurl which requires new measures-data
  - measures-data-srpm script for building local SRPMS
  - carta-beta 5.0+2025.7.22 has been updated to carta v5.0.0