### PR TITLE
Posh/enable scripting

### DIFF
--- a/macOS_electron/files/pack/carta-backend/bin/carta.sh
+++ b/macOS_electron/files/pack/carta-backend/bin/carta.sh
@@ -12,4 +12,4 @@ if [[ ! " $@ " =~ ( --version | -v | --help | -h ) ]]; then
     fi
 fi
 
-$dirname/carta_backend $@ --frontend_folder=$dirname/../../
+$dirname/carta_backend $@ --frontend_folder=$dirname/../../ --enable_scripting

--- a/macOS_electron/files/pack/carta-backend/bin/run.sh
+++ b/macOS_electron/files/pack/carta-backend/bin/run.sh
@@ -17,4 +17,4 @@ fi
 
 $dirname/casa_data_autoupdate
 
-CARTA_AUTH_TOKEN="$1" "$dirname"/carta_backend "$2" --port="$3" --frontend_folder="$dirname"/../../ --no_browser "${@:4}"
+CARTA_AUTH_TOKEN="$1" "$dirname"/carta_backend "$2" --port="$3" --frontend_folder="$dirname"/../../ --no_browser "${@:4}" --enable_scripting

--- a/macOS_electron/files/pack/package.json
+++ b/macOS_electron/files/pack/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@electron/notarize": "^3.1.1",
     "electron-builder-notarize": "1.5.2",
-    "electron": "39.8.5",
+    "electron": "39.8.10",
     "electron-packager": "^17.1.1",
     "electron-builder": "^26.0.12"
   },


### PR DESCRIPTION
# Enable scripting as default in mac electron app
- Adding --enable_scripting to enable HTTP scripting interface: https://carta.readthedocs.io/en/latest/installation_and_configuration.html

# 
- Bump electron version: 39.8.10